### PR TITLE
Reverse order of entries in the changelog to have recent entries first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
-## 0.1.0 - First Release
-* Every feature added
-* Every bug fixed
+## 1.5.0
+* Jumpy now works with code folding and soft wraps (word wraps).
+* NOTE: vim-mode seems to have very unexpected behavior with toggles and
+  word wraps (even with Jumpy disabled).  Better behavior in insert mode!
+* Although there are a few more features in the pipeline planned.
+  This completes the last of the known unexpected behavior (bugs).
+
+## 1.4.1
+* Added some very useful instructions about how to bind 'f' to
+  jumpy:toggle.  This of course replaces native 'f' functionality.
+
+## 1.4.0
+* Jumpy now clears irrelevant labels after the firs character is
+  entered.  This helps home in on your target.
+
+## 1.3.1
+* Fixes shift-enter (backward search) on find and replace's mini pane.
+
+## 1.3.0
+* Adds new homing beacon feature with setting to disable.
+* Adds some missing spec tests.
 
 ## 0.1.7
 * Reset current first character entered (triggered with backspace)
@@ -8,24 +26,6 @@
 * Working spec tests
 * No known bugs
 
-## 1.3.0
-* Adds new homing beacon feature with setting to disable.
-* Adds some missing spec tests.
-
-## 1.3.1
-* Fixes shift-enter (backward search) on find and replace's mini pane.
-
-## 1.4.0
-* Jumpy now clears irrelevant labels after the firs character is
-  entered.  This helps home in on your target.
-
-## 1.4.1
-* Added some very useful instructions about how to bind 'f' to
-  jumpy:toggle.  This of course replaces native 'f' functionality.
-
-## 1.5.0
-* Jumpy now works with code folding and soft wraps (word wraps).
-* NOTE: vim-mode seems to have very unexpected behavior with toggles and
-  word wraps (even with Jumpy disabled).  Better behavior in insert mode!
-* Although there are a few more features in the pipeline planned.
-  This completes the last of the known unexpected behavior (bugs).
+## 0.1.0 - First Release
+* Every feature added
+* Every bug fixed


### PR DESCRIPTION
I thought it could be better to have recent entries first in the changelog, so when you read it you don't have to scroll to see new changes. Are you okay with that?
