### PR TITLE
replaced deprecated selectors

### DIFF
--- a/keymaps/jumpy.cson
+++ b/keymaps/jumpy.cson
@@ -7,10 +7,10 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace .editor:not(.mini)':
+'atom-workspace atom-text-editor:not(.mini)':
     'shift-enter': 'jumpy:toggle'
 
-'.workspace .editor.jumpy-jump-mode':
+'atom-workspace atom-text-editor.jumpy-jump-mode':
     'backspace': 'jumpy:reset'
     'enter': 'jumpy:clear'
     'space': 'jumpy:clear'


### PR DESCRIPTION
replaced deprecated .workspace and .editor selectors with atom-workseace and atom-text-editor tags