### PR TITLE
fix: use temporary markers for beacons

### DIFF
--- a/lib/jumpy-view.coffee
+++ b/lib/jumpy-view.coffee
@@ -256,7 +256,7 @@ class JumpyView extends View
         location = @findLocation()
         if location == null
             return
-        @disposables.add atom.workspace.observeTextEditors (currentEditor) ->
+        @disposables.add atom.workspace.observeTextEditors (currentEditor) =>
             editorView = atom.views.getView(currentEditor)
 
             # Prevent other editors from jumping cursors as well
@@ -274,15 +274,22 @@ class JumpyView extends View
             else
                 currentEditor.setCursorScreenPosition location.position
 
-            useHomingBeacon =
-                atom.config.get 'jumpy.useHomingBeaconEffectOnJumps'
-            if useHomingBeacon
-                cursor = editorView.shadowRoot.querySelector '.cursors .cursor'
-                if cursor
-                    cursor.classList.add 'beacon'
-                    setTimeout ->
-                        cursor.classList.remove 'beacon'
-                    , 150
+            @beacon currentEditor, location
+
+    beacon: (editor, location) ->
+      useHomingBeacon =
+          atom.config.get 'jumpy.useHomingBeaconEffectOnJumps'
+      return unless useHomingBeacon
+      range = Range.fromObject [location.position, location.position]
+      marker = editor.markScreenRange range, invalidate: 'never'
+      beacon = document.createElement 'span'
+      beacon.classList.add 'beacon'
+      decoration = editor.decorateMarker marker,
+        item: beacon,
+        type: 'overlay'
+      setTimeout ->
+        marker.destroy()
+      , 150
 
     findLocation: ->
         label = "#{@firstChar}#{@secondChar}"

--- a/spec/jumpy-spec.coffee
+++ b/spec/jumpy-spec.coffee
@@ -101,7 +101,7 @@ describe "Jumpy", ->
             expect(decorations[83].getProperties().item.textContent).toBe 'df'
         it "clears beacon effect", ->
             expect(textEditorElement.
-                querySelectorAll('cursors .cursor.beacon').length).toBe 0
+                querySelectorAll('span.beacon').length).toBe 0
         it "only uses jumpy keymaps", ->
             expect(atom.keymaps.keyBindings.length).toBe (26 * 2) + 5 + 1
 
@@ -140,12 +140,15 @@ describe "Jumpy", ->
 
     describe "when the jumpy:toggle event is triggered
     and hotkeys are entered", ->
-        it "jumpy is cleared", ->
+        it "jumpy is cleared", (done) ->
             atom.commands.dispatch workspaceElement, 'jumpy:a'
             atom.commands.dispatch workspaceElement, 'jumpy:c'
             expect(textEditorElement.classList
                 .contains('jumpy-jump-mode')).toBe false
-            expect(textEditor.getOverlayDecorations()).toHaveLength 0
+            setTimeout ->
+              expect(textEditor.getOverlayDecorations()).toHaveLength 0
+              done()
+            , 160
 
     describe "when the jumpy:toggle event is triggered
     and invalid hotkeys are entered", ->
@@ -205,7 +208,7 @@ describe "Jumpy", ->
         it "the beacon animation class is added", ->
             atom.commands.dispatch workspaceElement, 'jumpy:a'
             atom.commands.dispatch workspaceElement, 'jumpy:c'
-            expect(textEditorElement.shadowRoot
+            expect(textEditorElement
                 .querySelectorAll('.beacon').length)
                 .toBe 1
         it "the beacon animation class is removed", ->
@@ -214,7 +217,7 @@ describe "Jumpy", ->
                 ->
                     atom.commands.dispatch workspaceElement, 'jumpy:c'
             runs ->
-                expect(textEditorElement.shadowRoot
+                expect(textEditorElement
                     .querySelectorAll('.beacon').length)
                     .toBe 0
 


### PR DESCRIPTION
Temporarily use a marker, with a `span.beacon` decoration to fix the beacon issue.

See #64