### PR TITLE
Tree View

### DIFF
--- a/keymaps/jumpy.cson
+++ b/keymaps/jumpy.cson
@@ -7,10 +7,11 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom-workspace atom-text-editor:not(.mini)':
+'*:not(.jumpy-jump-mode) atom-workspace atom-text-editor:not(.mini),
+ *:not(.jumpy-jump-mode) atom-workspace .tree-view':
     'shift-enter': 'jumpy:toggle'
 
-'atom-workspace atom-text-editor.jumpy-jump-mode':
+'.jumpy-jump-mode atom-workspace':
     'backspace': 'jumpy:reset'
     'enter': 'jumpy:clear'
     'space': 'jumpy:clear'

--- a/lib/jumpy-view.coffee
+++ b/lib/jumpy-view.coffee
@@ -1,9 +1,8 @@
-# FIXME: Beacon code (currently broken in shadow).  This will probably return
-# in the form of a decoration with a "flash", not sure yet.
 # TODO: Merge in @willdady's code for better accuracy.
 # TODO: Remove space-pen?
 
 ### global atom ###
+Labels = require './labels'
 {CompositeDisposable, Point, Range} = require 'atom'
 {View, $} = require 'space-pen'
 _ = require 'lodash'

--- a/lib/label-manager-iterator.coffee
+++ b/lib/label-manager-iterator.coffee
@@ -1,0 +1,73 @@
+{CompositeDisposable, Point, Range} = require 'atom'
+fs = require 'fs'
+pathHelper = require 'path'
+_ = require 'lodash'
+
+LABEL_MANAGER_PATH = pathHelper.join __dirname, 'label-managers'
+labelManagers = fs
+    .readdirSync(LABEL_MANAGER_PATH)
+    .map((file) -> require(pathHelper.join LABEL_MANAGER_PATH, file))
+
+lowerCharacters =
+    (String.fromCharCode(a) for a in ['a'.charCodeAt()..'z'.charCodeAt()])
+upperCharacters =
+    (String.fromCharCode(a) for a in ['A'.charCodeAt()..'Z'.charCodeAt()])
+keys = []
+
+# A little ugly.
+# I used itertools.permutation in python.
+# Couldn't find a good one in npm.  Don't worry this takes < 1ms once.
+for c1 in lowerCharacters
+    for c2 in lowerCharacters
+        keys.push c1 + c2
+for c1 in upperCharacters
+    for c2 in lowerCharacters
+        keys.push c1 + c2
+for c1 in lowerCharacters
+    for c2 in upperCharacters
+        keys.push c1 + c2
+
+class LabelManagerIterator
+    constructor: (disposables) ->
+        @clickableLabels = []
+        @labelManagers = labelManagers.map((Manager) -> new Manager disposables)
+        atom.config.observe 'jumpy.fontSize', @setFontSize
+        atom.config.observe 'jumpy.matchPattern', @setWordsPattern
+        atom.config.observe 'jumpy.highContrast', @setHighContrast
+
+    setHighContrast: (value) =>
+        manager.highContrast = value for manager in @labelManagers
+
+    setWordsPattern: (value) =>
+        value = new RegExp value, 'g'
+        manager.matchPattern = value for manager in @labelManagers
+
+    setFontSize: (value) =>
+        value = .75 if isNaN(value) or value > 1
+        value = (value * 100) + '%'
+        manager.fontSize = value for manager in @labelManagers
+
+    toggle: ->
+        nextKeys = _.clone keys
+        manager.toggle nextKeys for manager in @labelManagers
+
+    jumpTo: (firstChar, secondChar) ->
+        manager.jumpTo firstChar, secondChar for manager in @labelManagers
+
+    destroy: ->
+        manager.destroy() for manager in @labelManagers
+
+    markIrrelevant: (firstChar) ->
+        manager.markIrrelevant firstChar for manager in @labelManagers
+
+    unmarkIrrelevant: ->
+        manager.unmarkIrrelevant() for manager in @labelManagers
+
+    findByCharacterAndPosition: (character, position) ->
+        found = null
+        for manager in @labelManagers
+            found = manager.findByCharacterAndPosition character, position
+            break if found
+        found
+
+module.exports = LabelManagerIterator

--- a/lib/label-manager.coffee
+++ b/lib/label-manager.coffee
@@ -1,0 +1,32 @@
+abstractMethod = (name) ->->
+    throw new Error "The abstract method #{name} needs to be created"
+
+class LabelManager
+    constructor: (@disposables) ->
+
+    createLabel: (text) ->
+        labelElement = document.createElement('span')
+        labelElement.textContent = text
+        labelElement.style.fontSize = @fontSize
+        labelElement.classList.add 'jumpy-label'
+        labelElement.classList.add 'high-contrast' if @highContrast
+        labelElement
+
+    createBeacon: ->
+        beacon = document.createElement 'span'
+        beacon.classList.add 'beacon'
+        beacon
+
+    toggle: abstractMethod 'toggle'
+
+    destroy: abstractMethod 'destroy'
+
+    markIrrelevant: abstractMethod 'markIrrelevant'
+
+    unmarkIrrelevant: abstractMethod 'unmarkIrrelevant'
+
+    findByCharacterAndPosition: abstractMethod 'findByCharacterAndPosition'
+
+    jumpTo: abstractMethod 'jumpTo'
+
+module.exports = LabelManager

--- a/lib/label-managers/text-editor.coffee
+++ b/lib/label-managers/text-editor.coffee
@@ -1,68 +1,18 @@
-{CompositeDisposable, Point, Range} = require 'atom'
+{Point, Range} = require 'atom'
 {$} = require 'space-pen'
-_ = require 'lodash'
+LabelManager = require '../label-manager'
 
-lowerCharacters =
-    (String.fromCharCode(a) for a in ['a'.charCodeAt()..'z'.charCodeAt()])
-upperCharacters =
-    (String.fromCharCode(a) for a in ['A'.charCodeAt()..'Z'.charCodeAt()])
-keys = []
-
-# A little ugly.
-# I used itertools.permutation in python.
-# Couldn't find a good one in npm.  Don't worry this takes < 1ms once.
-for c1 in lowerCharacters
-    for c2 in lowerCharacters
-        keys.push c1 + c2
-for c1 in upperCharacters
-    for c2 in lowerCharacters
-        keys.push c1 + c2
-for c1 in lowerCharacters
-    for c2 in upperCharacters
-        keys.push c1 + c2
-
-class Labels
-    constructor: (@disposables = new CompositeDisposable()) ->
+class TextEditorLabelManager extends LabelManager
+    constructor: (args...) ->
+        super args...
         @allPositions = {}
         @decorations = []
-        atom.config.observe 'jumpy.fontSize', @setFontSize
-        atom.config.observe 'jumpy.matchPattern', @setWordsPattern
-        atom.config.observe 'jumpy.highContrast', @setHighContrast
 
-    setHighContrast: (value) =>
-        @highContrast = value
-
-    setWordsPattern: (value) =>
-        @matchPattern = new RegExp value, 'g'
-
-    setFontSize: (value) =>
-        value = .75 if isNaN(value) or value > 1
-        @fontSize = (value * 100) + '%'
-
-    createLabel: (text) ->
-        labelElement = document.createElement('span')
-        labelElement.textContent = text
-        labelElement.style.fontSize = @fontSize
-        labelElement.classList.add 'jumpy-label'
-        labelElement.classList.add 'high-contrast' if @highContrast
-        labelElement
-
-    toggleTreeView: (keys) ->
-        elements = document.querySelectorAll(
-            '.tree-view li.file, .tree-view li.directory.collapsed')
-        for element in elements
-            return unless keys.length
-            label = @createLabel keys.shift()
-            element.parentNode.insertBefore label, element
-
-    toggleInTextEditors: (keys) ->
+    toggle: (keys) ->
         @disposables.add atom.workspace.observeTextEditors (editor) =>
             editorView = atom.views.getView(editor)
             $editorView = $(editorView)
             return if $editorView.is ':not(:visible)'
-
-            # 'jumpy-jump-mode is for keymaps and utilized by tests
-            editorView.classList.add 'jumpy-jump-mode'
 
             getVisibleColumnRange = (editorView) ->
                 charWidth = editorView.getDefaultCharacterWidth()
@@ -116,9 +66,41 @@ class Labels
                         if column > minColumn && column < maxColumn
                             drawLabels lineNumber, column
 
-    toggle: ->
-        nextKeys = _.clone keys
-        @toggleInTextEditors nextKeys
+    jumpTo: (firstChar, secondChar) ->
+        location = @findLocation firstChar, secondChar
+        if location == null
+            return
+        @disposables.add atom.workspace.observeTextEditors (currentEditor) =>
+            editorView = atom.views.getView(currentEditor)
+
+            # Prevent other editors from jumping cursors as well
+            # TODO: make a test for this return if
+            return if currentEditor.id != location.editor
+
+            pane = atom.workspace.paneForItem(currentEditor)
+            pane.activate()
+
+            isVisualMode = editorView.classList.contains 'visual-mode'
+            isSelected = (currentEditor.getSelections().length == 1 &&
+                currentEditor.getSelectedText() != '')
+            if (isVisualMode || isSelected)
+                currentEditor.selectToScreenPosition location.position
+            else
+                currentEditor.setCursorScreenPosition location.position
+
+            if atom.config.get 'jumpy.useHomingBeaconEffectOnJumps'
+                @drawBeacon currentEditor, location
+
+    drawBeacon: (editor, location) ->
+        range = Range location.position, location.position
+        marker = editor.markScreenRange range, invalidate: 'never'
+        beacon = @createBeacon()
+        editor.decorateMarker marker,
+            item: beacon,
+            type: 'overlay'
+        setTimeout ->
+            marker.destroy()
+        , 150
 
     destroy: ->
         decoration.getMarker().destroy() for decoration in @decorations
@@ -127,8 +109,7 @@ class Labels
 
     findLocation: (firstChar, secondChar) ->
         label = "#{firstChar}#{secondChar}"
-        return @allPositions[label] if label of @allPositions
-        null
+        @allPositions[label] || null
 
     markIrrelevant: (firstChar) ->
         for decoration in @decorations
@@ -144,5 +125,6 @@ class Labels
         for decoration in @decorations
             element = decoration.getProperties().item
             return decoration if element.textContent[position] == character
+        null
 
-module.exports = Labels
+module.exports = TextEditorLabelManager

--- a/lib/label-managers/tree-view.coffee
+++ b/lib/label-managers/tree-view.coffee
@@ -1,0 +1,61 @@
+LabelManager = require '../label-manager'
+
+triggerMouseEvent = (element, eventType) ->
+    clickEvent = document.createEvent 'MouseEvents'
+    clickEvent.initEvent eventType, true, true
+    element.dispatchEvent clickEvent
+
+class TreeViewManager extends LabelManager
+    constructor: (args...) ->
+        super args...
+        @locations = []
+
+    toggle: (keys) ->
+        elements = document.querySelectorAll '.tree-view *[data-path]'
+        for element in elements
+            return unless keys.length
+            label = @createLabel keys.shift()
+            @locations.push {label, element}
+            element.parentNode.insertBefore label, element
+
+    destroy: ->
+        while location = @locations.shift()
+            location.label.parentNode.removeChild location.label
+
+    drawBeacon: ({element}) ->
+        beacon = @createBeacon()
+        parent = element.parentNode
+        parent.insertBefore beacon, element
+        setTimeout ->
+            parent.removeChild beacon
+        , 150
+
+    jumpTo: (firstChar, secondChar) ->
+        match = "#{firstChar}#{secondChar}"
+        location = @locations.find(({label}) -> label.textContent is match)
+        return unless location
+        @drawBeacon location
+        @select location
+
+    select: ({element}) ->
+        atom.commands.dispatch(
+            document.querySelector('atom-workspace'),
+            'tree-view:show'
+        )
+        triggerMouseEvent element, 'mousedown'
+        atom.commands.dispatch element, 'tree-view:open-selected-entry'
+
+    markIrrelevant: (firstChar) ->
+        @locations
+            .filter(({label}) -> not label.textContent.includes firstChar)
+            .forEach(({label}) -> label.classList.add 'irrelevant')
+
+    unmarkIrrelevant: ->
+        label.classList.remove 'irrelevant' for {label} in @locations
+
+    findByCharacterAndPosition: (character, position) ->
+        for {label} in @locations
+            return label if label.textContent[position] is character
+        null
+
+module.exports = TreeViewManager

--- a/lib/labels.coffee
+++ b/lib/labels.coffee
@@ -1,0 +1,148 @@
+{CompositeDisposable, Point, Range} = require 'atom'
+{$} = require 'space-pen'
+_ = require 'lodash'
+
+lowerCharacters =
+    (String.fromCharCode(a) for a in ['a'.charCodeAt()..'z'.charCodeAt()])
+upperCharacters =
+    (String.fromCharCode(a) for a in ['A'.charCodeAt()..'Z'.charCodeAt()])
+keys = []
+
+# A little ugly.
+# I used itertools.permutation in python.
+# Couldn't find a good one in npm.  Don't worry this takes < 1ms once.
+for c1 in lowerCharacters
+    for c2 in lowerCharacters
+        keys.push c1 + c2
+for c1 in upperCharacters
+    for c2 in lowerCharacters
+        keys.push c1 + c2
+for c1 in lowerCharacters
+    for c2 in upperCharacters
+        keys.push c1 + c2
+
+class Labels
+    constructor: (@disposables = new CompositeDisposable()) ->
+        @allPositions = {}
+        @decorations = []
+        atom.config.observe 'jumpy.fontSize', @setFontSize
+        atom.config.observe 'jumpy.matchPattern', @setWordsPattern
+        atom.config.observe 'jumpy.highContrast', @setHighContrast
+
+    setHighContrast: (value) =>
+        @highContrast = value
+
+    setWordsPattern: (value) =>
+        @matchPattern = new RegExp value, 'g'
+
+    setFontSize: (value) =>
+        value = .75 if isNaN(value) or value > 1
+        @fontSize = (value * 100) + '%'
+
+    createLabel: (text) ->
+        labelElement = document.createElement('span')
+        labelElement.textContent = text
+        labelElement.style.fontSize = @fontSize
+        labelElement.classList.add 'jumpy-label'
+        labelElement.classList.add 'high-contrast' if @highContrast
+        labelElement
+
+    toggleTreeView: (keys) ->
+        elements = document.querySelectorAll(
+            '.tree-view li.file, .tree-view li.directory.collapsed')
+        for element in elements
+            return unless keys.length
+            label = @createLabel keys.shift()
+            element.parentNode.insertBefore label, element
+
+    toggleInTextEditors: (keys) ->
+        @disposables.add atom.workspace.observeTextEditors (editor) =>
+            editorView = atom.views.getView(editor)
+            $editorView = $(editorView)
+            return if $editorView.is ':not(:visible)'
+
+            # 'jumpy-jump-mode is for keymaps and utilized by tests
+            editorView.classList.add 'jumpy-jump-mode'
+
+            getVisibleColumnRange = (editorView) ->
+                charWidth = editorView.getDefaultCharacterWidth()
+                # FYI: asserts:
+                # numberOfVisibleColumns = editorView.getWidth() / charWidth
+                minColumn = (editorView.getScrollLeft() / charWidth) - 1
+                maxColumn = editorView.getScrollRight() / charWidth
+
+                return [
+                    minColumn
+                    maxColumn
+                ]
+
+            drawLabels = (lineNumber, column) =>
+                return unless keys.length
+
+                keyLabel = keys.shift()
+                position = {row: lineNumber, column: column}
+                # creates a reference:
+                @allPositions[keyLabel] =
+                    editor: editor.id
+                    position: position
+
+                marker = editor.markScreenRange new Range(
+                    new Point(lineNumber, column),
+                    new Point(lineNumber, column)),
+                    invalidate: 'touch'
+
+                decoration = editor.decorateMarker marker,
+                    type: 'overlay'
+                    item: @createLabel keyLabel
+                    position: 'head'
+
+                @decorations.push decoration
+
+            [minColumn, maxColumn] = getVisibleColumnRange editorView
+            rows = editor.getVisibleRowRange()
+            return unless rows
+
+            [firstVisibleRow, lastVisibleRow] = rows
+            # TODO: Right now there are issues with lastVisbleRow
+            for lineNumber in [firstVisibleRow...lastVisibleRow]
+                lineContents = editor.lineTextForScreenRow(lineNumber)
+                if editor.isFoldedAtScreenRow(lineNumber)
+                    drawLabels lineNumber, 0
+                else
+                    while ((word = @matchPattern.exec(lineContents)) != null)
+                        column = word.index
+                        # Do not do anything... markers etc.
+                        # if the columns are out of bounds...
+                        if column > minColumn && column < maxColumn
+                            drawLabels lineNumber, column
+
+    toggle: ->
+        nextKeys = _.clone keys
+        @toggleInTextEditors nextKeys
+
+    destroy: ->
+        decoration.getMarker().destroy() for decoration in @decorations
+        @decorations = [] # Very important for GC.
+        # Verifiable in Dev Tools -> Timeline -> Nodes.
+
+    findLocation: (firstChar, secondChar) ->
+        label = "#{firstChar}#{secondChar}"
+        return @allPositions[label] if label of @allPositions
+        null
+
+    markIrrelevant: (firstChar) ->
+        for decoration in @decorations
+            element = decoration.getProperties().item
+            if element.textContent.indexOf(firstChar) != 0
+                element.classList.add 'irrelevant'
+
+    unmarkIrrelevant: ->
+        for decoration in @decorations
+            decoration.getProperties().item.classList.remove 'irrelevant'
+
+    findByCharacterAndPosition: (character, position) ->
+        for decoration in @decorations
+            element = decoration.getProperties().item
+            return decoration if element.textContent[position] == character
+
+module.exports = Labels

--- a/spec/jumpy-spec.coffee
+++ b/spec/jumpy-spec.coffee
@@ -169,7 +169,7 @@ describe "Jumpy", ->
             expect(cursorPosition.column).toBe 6
             expect(textEditor.getSelectedText()).toBe ''
         it "clears jumpy mode", ->
-            expect(textEditorElement
+            expect(atom.document.body
                 .classList.contains('jumpy-jump-mode')).toBeTruthy()
             atom.commands.dispatch workspaceElement, 'jumpy:a'
             atom.commands.dispatch workspaceElement, 'jumpy:c'

--- a/styles/.atom-text-editor.less
+++ b/styles/.atom-text-editor.less
@@ -23,6 +23,11 @@
     &.high-contrast {
         background-color: @background-color-success;
     }
+
+    .tree-view & {
+        transform: translate(0, 0);
+        z-index: 11;
+    }
 }
 
 @import "beacon.less";


### PR DESCRIPTION
1st of all... this started off as more of a POC which exgallated somewhat. Feel free to use a much or **little** of this as you like.

This is what was going through my head:

There needs to be different behaviours for jumpy depending on what we're jumping to. As I could see the potential for this logic to grow I first separated all the "label logic" (label creation, destruction, filtering, selection, beaconing etc) in to a separate module. Then it became quickly apparent that this module was simply going to be an iterator (of sorts) that would abstract different label behaviours. I've called these "label-managers".

An instance of `label-manager-iterator` is set as a property of the `jumpy-view` and whenever some kind of "label" function needs to happen, the `jumpy-view` calls a method on the `label-manager-iterator`.

The `label-manager-iterator` does exactly what it says on the tin; calls the same method on all `label-manager`'s. There's currently one for text editors and one for the tree view.

That's essentially it.

There are no tests yet. As I said... it's a POC we can bosh out some tests if/when a design is laid out. I didn't want to make any tests if this was going to be chucked.

See #70
