### PR TITLE
Remove object observe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3 - Remove deprecation (Object.observe)
+*   Simplify and Remove logic that used Object.observe for key maps.
+
 ## 3.1.2 - Fix beacon
 *   Merge @johngeorgewright PR to restore the beacon functionality!
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Note: Styles can be overridden in **'Atom' -> 'Open Your Stylesheet'**
 (see examples below)
 
 ```less
-atom-text-editor /deep/ {
+atom-text-editor {
     .jumpy-label {
         // Regular labels
         background-color: black;

--- a/lib/jumpy-view.coffee
+++ b/lib/jumpy-view.coffee
@@ -113,8 +113,7 @@ class JumpyView extends View
 
     getFilteredJumpyKeys: ->
         atom.keymaps.keyBindings.filter (keymap) ->
-            keymap.command
-                .indexOf('jumpy') > -1 if typeof keymap.command is 'string'
+            keymap.command.includes 'jumpy' if typeof keymap.command is 'string'
 
     turnOffSlowKeys: ->
         atom.keymaps.keyBindings = @getFilteredJumpyKeys()

--- a/lib/jumpy-view.coffee
+++ b/lib/jumpy-view.coffee
@@ -1,5 +1,4 @@
-# FIXME: Beacon code (currently broken in shadow).  This will probably return
-# in the form of a decoration with a "flash", not sure yet.
+# TODO: Merge in @johngeorgewright's code for treeview
 # TODO: Merge in @willdady's code for better accuracy.
 # TODO: Remove space-pen?
 

--- a/lib/jumpy-view.coffee
+++ b/lib/jumpy-view.coffee
@@ -58,8 +58,6 @@ class JumpyView extends View
             priority: -1
         @statusBarJumpy = document.getElementById 'status-bar-jumpy'
 
-        @initKeyFilters()
-
     getKey: (character) ->
         @statusBarJumpy?.classList.remove 'no-match'
 
@@ -113,19 +111,13 @@ class JumpyView extends View
         @statusBarJumpy?.classList.remove 'no-match'
         @statusBarJumpyStatus?.innerHTML = 'Jump Mode!'
 
-    initKeyFilters: ->
-        @filteredJumpyKeys = @getFilteredJumpyKeys()
-        Object.observe atom.keymaps.keyBindings, ->
-            @filteredJumpyKeys = @getFilteredJumpyKeys()
-        # Don't think I need a corresponding unobserve
-
     getFilteredJumpyKeys: ->
         atom.keymaps.keyBindings.filter (keymap) ->
             keymap.command
                 .indexOf('jumpy') > -1 if typeof keymap.command is 'string'
 
     turnOffSlowKeys: ->
-        atom.keymaps.keyBindings = @filteredJumpyKeys
+        atom.keymaps.keyBindings = @getFilteredJumpyKeys()
 
     toggle: ->
         @clearJumpMode()

--- a/styles/theme-atom-material-ui.atom-text-editor.less
+++ b/styles/theme-atom-material-ui.atom-text-editor.less
@@ -2,7 +2,7 @@
 .jumpy-label {
     color: @text-color;
     background-color: @base-background-color;
-    
+
     &.high-contrast {
         color: @text-color;
         background-color: @background-color-success;


### PR DESCRIPTION
Object.observe() will not be in the newer electron's as it's removed from chrome.

I really don't think I ever needed this to begin with.  I was trying to over optimize I think.  Just re runs the linear scan avoiding weird ordering issues with changing keys etc.